### PR TITLE
Pip resolver dep fix

### DIFF
--- a/{{ cookiecutter.project_name }}/requirements.txt
+++ b/{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/inmanta/inmanta.git
+inmanta
 pep8-naming
 flake8
 flake8-black

--- a/{{ cookiecutter.project_name }}/requirements.txt
+++ b/{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,3 @@
-inmanta
 pep8-naming
 flake8
 flake8-black


### PR DESCRIPTION
Using nameless dependencies is not allowed as a constraint
And our extensions don't actually have a inmanta listed in their requirements.txt files