### PR TITLE
dropped tox-venv installation from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
       steps{
         sh '''
           source ${WORKSPACE}/env/bin/activate
-          pip install -c ${WORKSPACE}/project/requirements.txt -U tox tox-venv setuptools pip isort black
+          pip install -c ${WORKSPACE}/project/requirements.txt -U tox setuptools pip isort black
           make -C ${WORKSPACE}/project build-pytest-inmanta-extensions format
         '''
       }


### PR DESCRIPTION
I don't think we need this anymore (tests succeed without) and I think it might even be discontinued (tests are failing on master atm).