### PR TITLE
added pytest-inmanta-extensions via inmanta-core extra

### DIFF
--- a/{{ cookiecutter.project_name }}/requirements.dev.txt
+++ b/{{ cookiecutter.project_name }}/requirements.dev.txt
@@ -1,2 +1,4 @@
+# Guide pip in finding appropriate versions by using the bound extra for pytest-inmanta-extensions.
+inmanta-core[pytest-inmanta-extensions]
 inmanta-dev-dependencies[pytest,async,extension]==2.82.0
 bumpversion==0.6.0


### PR DESCRIPTION
Turns out inmanta/inmanta-core#6472 does not suffice because it doesn't impact versions that have already been released.